### PR TITLE
Rename health status metric namespace

### DIFF
--- a/internal/wavefront/senders/status/sender.go
+++ b/internal/wavefront/senders/status/sender.go
@@ -66,7 +66,7 @@ func (s Sender) sendOperatorStatus(status wf.WavefrontStatus, clusterName string
 		healthy = 1.0
 	}
 
-	err := s.sendMetric("kubernetes.operator-system.status", healthy, clusterName, tags)
+	err := s.sendMetric("kubernetes.observability.status", healthy, clusterName, tags)
 	if err != nil {
 		return err
 	}
@@ -117,7 +117,7 @@ func (s Sender) sendComponentStatus(resourceStatuses []wf.ResourceStatus, cluste
 		tags["message"] = strings.Join(resourceMessages(componentStatuses), "; ")
 		healthValue = 0.0
 	}
-	return s.sendMetric(fmt.Sprintf("kubernetes.operator-system.%s.status", strings.ToLower(componentName)), healthValue, clusterName, tags)
+	return s.sendMetric(fmt.Sprintf("kubernetes.observability.%s.status", strings.ToLower(componentName)), healthValue, clusterName, tags)
 }
 
 func resourceMessages(statuses []wf.ResourceStatus) []string {

--- a/internal/wavefront/senders/status/sender_test.go
+++ b/internal/wavefront/senders/status/sender_test.go
@@ -26,7 +26,7 @@ func TestWavefrontProxySender(t *testing.T) {
 
 func TestSender(t *testing.T) {
 	t.Run("sends empty wavefront status", func(t *testing.T) {
-		expectedMetricLine := testhelper.NewMockMetricClient(testhelper.AssertContainsLine("kubernetes.operator-system.status 0.000000 source=\"my_cluster\""))
+		expectedMetricLine := testhelper.NewMockMetricClient(testhelper.AssertContainsLine("kubernetes.observability.status 0.000000 source=\"my_cluster\""))
 		sender := status.NewSender(expectedMetricLine)
 
 		_ = sender.SendStatus(wf.WavefrontStatus{}, "my_cluster")
@@ -35,7 +35,7 @@ func TestSender(t *testing.T) {
 	})
 
 	t.Run("sends healthy wavefront status", func(t *testing.T) {
-		expectedMetricLine := testhelper.NewMockMetricClient(testhelper.AssertContainsLine("kubernetes.operator-system.status 1.000000 source=\"my_cluster\" message=\"1/1 components are healthy\" status=\"Healthy\""))
+		expectedMetricLine := testhelper.NewMockMetricClient(testhelper.AssertContainsLine("kubernetes.observability.status 1.000000 source=\"my_cluster\" message=\"1/1 components are healthy\" status=\"Healthy\""))
 		sender := status.NewSender(expectedMetricLine)
 
 		_ = sender.SendStatus(wf.WavefrontStatus{Status: "Healthy", Message: "1/1 components are healthy"}, "my_cluster")
@@ -44,7 +44,7 @@ func TestSender(t *testing.T) {
 	})
 
 	t.Run("sends unhealthy wavefront status", func(t *testing.T) {
-		expectedMetricLine := testhelper.NewMockMetricClient(testhelper.AssertContainsLine("kubernetes.operator-system.status 0.000000 source=\"my_cluster\" message=\"0/1 components are healthy\" status=\"Unhealthy\""))
+		expectedMetricLine := testhelper.NewMockMetricClient(testhelper.AssertContainsLine("kubernetes.observability.status 0.000000 source=\"my_cluster\" message=\"0/1 components are healthy\" status=\"Unhealthy\""))
 		sender := status.NewSender(expectedMetricLine)
 
 		_ = sender.SendStatus(wf.WavefrontStatus{Status: "Unhealthy", Message: "0/1 components are healthy"}, "my_cluster")
@@ -53,7 +53,7 @@ func TestSender(t *testing.T) {
 	})
 
 	t.Run("sends wavefront status with point tag exceeds length limit", func(t *testing.T) {
-		expectedMetricLine := testhelper.NewMockMetricClient(testhelper.AssertContainsLine("kubernetes.operator-system.status 0.000000 source=\"my_cluster\" message=\"0/1 components are healthy. Error: this is a dummy error message with its length exceeds 256 and characters; 0/1 components are healthy. Error: this is a dummy error message with its length exceeds 256 and characters; 0/1 components are healthy. E\" status=\"Unhealthy\""))
+		expectedMetricLine := testhelper.NewMockMetricClient(testhelper.AssertContainsLine("kubernetes.observability.status 0.000000 source=\"my_cluster\" message=\"0/1 components are healthy. Error: this is a dummy error message with its length exceeds 256 and characters; 0/1 components are healthy. Error: this is a dummy error message with its length exceeds 256 and characters; 0/1 components are healthy. E\" status=\"Unhealthy\""))
 		sender := status.NewSender(expectedMetricLine)
 
 		_ = sender.SendStatus(wf.WavefrontStatus{
@@ -87,7 +87,7 @@ func TestSender(t *testing.T) {
 		ReportsSubComponentMetric(t, "Metrics", []string{util.ClusterCollectorName, util.NodeCollectorName})
 
 		t.Run("sends unhealthy status when cluster and node collector are unhealthy", func(t *testing.T) {
-			expectedMetricLine := testhelper.NewMockMetricClient(testhelper.AssertContainsLine("kubernetes.operator-system.metrics.status 0.000000 source=\"my_cluster\" message=\"cluster collector has an error; node collector has an error\" status=\"unhealthy\""))
+			expectedMetricLine := testhelper.NewMockMetricClient(testhelper.AssertContainsLine("kubernetes.observability.metrics.status 0.000000 source=\"my_cluster\" message=\"cluster collector has an error; node collector has an error\" status=\"unhealthy\""))
 			sender := status.NewSender(expectedMetricLine)
 
 			_ = sender.SendStatus(
@@ -124,7 +124,7 @@ func TestSender(t *testing.T) {
 }
 
 func ReportsSubComponentMetric(t *testing.T, componentName string, resourceNames []string) {
-	metricName := fmt.Sprintf("kubernetes.operator-system.%s.status", strings.ToLower(componentName))
+	metricName := fmt.Sprintf("kubernetes.observability.%s.status", strings.ToLower(componentName))
 
 	t.Run("sends healthy status", func(t *testing.T) {
 		expectedMetricLine := testhelper.NewMockMetricClient(testhelper.AssertContainsLine(


### PR DESCRIPTION
Rename health status metric namespace from operator-system to observability