### PR TITLE
Upload 2.0.0 OSL and use it in fluentd docker image as well

### DIFF
--- a/Dockerfile.fluentd
+++ b/Dockerfile.fluentd
@@ -19,4 +19,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev" \
  && rm -rf /var/lib/apÏt/lists/* \
  && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem
 
+COPY open_source_licenses.txt .
+
 ENTRYPOINT ["tini",  "--", "/bin/entrypoint.sh"]


### PR DESCRIPTION
Co-authored-by: Mark Michael <mamichael@vmware.com>