### PR TITLE
Make scenario setup declarative

### DIFF
--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the  v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=wavefront.com
+// +kubebuilder:object:generate=true
+// +groupName=wavefront.com
 package v1alpha1
 
 import (

--- a/internal/testhelper/wftest/cr.go
+++ b/internal/testhelper/wftest/cr.go
@@ -2,20 +2,16 @@ package wftest
 
 import (
 	wf "github.com/wavefrontHQ/wavefront-operator-for-kubernetes/api/v1alpha1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type CROption func(*wf.Wavefront)
-
-func CR(options ...CROption) *wf.Wavefront {
+func CR(options ...func(*wf.Wavefront)) *wf.Wavefront {
 	cr := &wf.Wavefront{
-		TypeMeta: v1.TypeMeta{},
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "wavefront",
-			Namespace: "testNamespace",
+			Namespace: DefaultNamespace,
 		},
 		Spec: wf.WavefrontSpec{
-			Namespace:            "testNamespace",
 			ClusterName:          "testClusterName",
 			WavefrontUrl:         "testWavefrontUrl",
 			WavefrontTokenSecret: "testToken",

--- a/internal/testhelper/wftest/ns.go
+++ b/internal/testhelper/wftest/ns.go
@@ -1,0 +1,3 @@
+package wftest
+
+const DefaultNamespace = "observability-test"

--- a/internal/testhelper/wftest/operator.go
+++ b/internal/testhelper/wftest/operator.go
@@ -1,0 +1,34 @@
+package wftest
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Operator(options ...func(*appsv1.Deployment)) *appsv1.Deployment {
+	operator := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "wavefront-controller-manager",
+			Namespace: DefaultNamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":      "wavefront",
+				"app.kubernetes.io/component": "controller-manager",
+			},
+			UID: "testUID",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image: "projects.registry.vmware.com/tanzu_observability/kubernetes-operator:latest",
+					}},
+				},
+			},
+		},
+	}
+	for _, option := range options {
+		option(operator)
+	}
+	return operator
+}

--- a/internal/testhelper/wftest/proxy.go
+++ b/internal/testhelper/wftest/proxy.go
@@ -1,0 +1,35 @@
+package wftest
+
+import (
+	"github.com/wavefrontHQ/wavefront-operator-for-kubernetes/internal/util"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Proxy(options ...func(*appsv1.Deployment)) *appsv1.Deployment {
+	proxy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      util.ProxyName,
+			Namespace: DefaultNamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":      "wavefront",
+				"app.kubernetes.io/component": "proxy",
+			},
+		},
+		Status: appsv1.DeploymentStatus{
+			AvailableReplicas: 1,
+			Replicas:          1,
+		},
+	}
+	for _, option := range options {
+		option(proxy)
+	}
+	return proxy
+}
+
+func WithReplicas(availableReplicas, replicas int) func(*appsv1.Deployment) {
+	return func(d *appsv1.Deployment) {
+		d.Status.AvailableReplicas = int32(availableReplicas)
+		d.Status.Replicas = int32(replicas)
+	}
+}


### PR DESCRIPTION
Each controller test should exercise one scenario (one call to reconcile). We accomplish this by making scenarios declarative and not exposing clients that could be used for modification.

There are now two setup functions
 * `emptyScenario`: only a controller deployment exists, you need to specify any resources over and above that
 * `componentScenario`: controller deployment + proxy deployment, so that components are ready to be spun up