### PR TITLE
Use one client for everything instead of three

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -60,10 +60,8 @@ rules:
   - create
   - delete
   - get
-  - list
   - patch
   - update
-  - watch
 - apiGroups:
   - apps
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -60,8 +60,10 @@ rules:
   - create
   - delete
   - get
+  - list
   - patch
   - update
+  - watch
 - apiGroups:
   - apps
   resources:

--- a/controllers/wavefront_controller.go
+++ b/controllers/wavefront_controller.go
@@ -85,7 +85,7 @@ type WavefrontReconciler struct {
 // but the operator doesn't need to... yet?
 // +kubebuilder:rbac:groups=apps,namespace=observability-system,resources=deployments,verbs=get;create;update;patch;delete;watch;list
 // +kubebuilder:rbac:groups="",namespace=observability-system,resources=services,verbs=get;create;update;patch;delete
-// +kubebuilder:rbac:groups=apps,namespace=observability-system,resources=daemonsets,verbs=get;create;update;patch;delete;watch;list
+// +kubebuilder:rbac:groups=apps,namespace=observability-system,resources=daemonsets,verbs=get;create;update;patch;delete;
 // +kubebuilder:rbac:groups="",namespace=observability-system,resources=serviceaccounts,verbs=get;create;update;patch;delete
 // +kubebuilder:rbac:groups="",namespace=observability-system,resources=configmaps,verbs=get;create;update;patch;delete
 // +kubebuilder:rbac:groups="",namespace=observability-system,resources=secrets,verbs=get;list;watch

--- a/controllers/wavefront_controller.go
+++ b/controllers/wavefront_controller.go
@@ -85,7 +85,7 @@ type WavefrontReconciler struct {
 // but the operator doesn't need to... yet?
 // +kubebuilder:rbac:groups=apps,namespace=observability-system,resources=deployments,verbs=get;create;update;patch;delete;watch;list
 // +kubebuilder:rbac:groups="",namespace=observability-system,resources=services,verbs=get;create;update;patch;delete
-// +kubebuilder:rbac:groups=apps,namespace=observability-system,resources=daemonsets,verbs=get;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,namespace=observability-system,resources=daemonsets,verbs=get;create;update;patch;delete;watch;list
 // +kubebuilder:rbac:groups="",namespace=observability-system,resources=serviceaccounts,verbs=get;create;update;patch;delete
 // +kubebuilder:rbac:groups="",namespace=observability-system,resources=configmaps,verbs=get;create;update;patch;delete
 // +kubebuilder:rbac:groups="",namespace=observability-system,resources=secrets,verbs=get;list;watch
@@ -264,10 +264,7 @@ func (r *WavefrontReconciler) readAndDeleteResources() error {
 
 func (r *WavefrontReconciler) deployment(name string) (*appsv1.Deployment, error) {
 	var deployment appsv1.Deployment
-	err := r.Client.Get(context.Background(), types.NamespacedName{
-		Namespace: r.namespace,
-		Name:      name,
-	}, &deployment)
+	err := r.Client.Get(context.Background(), util.ObjKey(r.namespace, name), &deployment)
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/wavefront_controller_test.go
+++ b/controllers/wavefront_controller_test.go
@@ -1011,11 +1011,11 @@ func emptyScenario(wfCR *wf.Wavefront, initObjs ...runtime.Object) (*controllers
 		initObjs = append(initObjs, operator)
 	}
 
-	clientBuilder := fake.NewClientBuilder()
+	clientBuilder := fake.NewClientBuilder().WithScheme(s)
 	if wfCR != nil {
-		clientBuilder = clientBuilder.WithScheme(s).WithObjects(wfCR)
+		clientBuilder = clientBuilder.WithObjects(wfCR)
 	}
-	clientBuilder = clientBuilder.WithScheme(s).WithRuntimeObjects(initObjs...)
+	clientBuilder = clientBuilder.WithRuntimeObjects(initObjs...)
 	objClient := clientBuilder.Build()
 
 	mockKM := testhelper.NewMockKubernetesManager()

--- a/controllers/wavefront_controller_test.go
+++ b/controllers/wavefront_controller_test.go
@@ -29,7 +29,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -1001,13 +1000,6 @@ func emptyScenario(wfCR *wf.Wavefront, initObjs ...runtime.Object) (*controllers
 	s := scheme.Scheme
 	s.AddKnownTypes(wf.GroupVersion, &wf.Wavefront{})
 
-	clientBuilder := fake.NewClientBuilder()
-	if wfCR != nil {
-		clientBuilder = clientBuilder.WithScheme(s).WithObjects(wfCR)
-	}
-	clientBuilder = clientBuilder.WithScheme(s).WithRuntimeObjects(initObjs...)
-	objClient := clientBuilder.Build()
-
 	namespace := wftest.DefaultNamespace
 	if wfCR != nil {
 		namespace = wfCR.Namespace
@@ -1019,18 +1011,21 @@ func emptyScenario(wfCR *wf.Wavefront, initObjs ...runtime.Object) (*controllers
 		initObjs = append(initObjs, operator)
 	}
 
-	fakeClient := k8sfake.NewSimpleClientset(initObjs...)
+	clientBuilder := fake.NewClientBuilder()
+	if wfCR != nil {
+		clientBuilder = clientBuilder.WithScheme(s).WithObjects(wfCR)
+	}
+	clientBuilder = clientBuilder.WithScheme(s).WithRuntimeObjects(initObjs...)
+	objClient := clientBuilder.Build()
 
 	mockKM := testhelper.NewMockKubernetesManager()
 
 	r := &controllers.WavefrontReconciler{
 		OperatorVersion:   "99.99.99",
 		Client:            objClient,
-		Scheme:            nil,
 		FS:                os.DirFS(controllers.DeployDir),
 		KubernetesManager: mockKM,
 		MetricConnection:  metric.NewConnection(testhelper.StubSenderFactory(nil, nil)),
-		TypedClient:       fakeClient,
 	}
 
 	return r, mockKM

--- a/controllers/wavefront_controller_test.go
+++ b/controllers/wavefront_controller_test.go
@@ -19,7 +19,6 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/stretchr/testify/require"
@@ -92,10 +91,11 @@ func TestReconcileAll(t *testing.T) {
 
 		var reconciledWFCR wf.Wavefront
 
-		require.NoError(t, r.Client.Get(context.Background(), types.NamespacedName{
-			Namespace: wfCR.Namespace,
-			Name:      wfCR.Name,
-		}, &reconciledWFCR))
+		require.NoError(t, r.Client.Get(
+			context.Background(),
+			util.ObjKey(wfCR.Namespace, wfCR.Name),
+			&reconciledWFCR,
+		))
 
 		require.Contains(t, reconciledWFCR.Status.Status, health.Unhealthy)
 		require.Contains(t, reconciledWFCR.Status.ResourceStatuses, wf.ResourceStatus{Status: "Running (1/1)", Name: "wavefront-proxy"})
@@ -1072,8 +1072,5 @@ func containsObject(runtimeObjs []runtime.Object, matches func(obj client.Object
 }
 
 func defaultRequest() reconcile.Request {
-	return reconcile.Request{NamespacedName: types.NamespacedName{
-		Namespace: wftest.DefaultNamespace,
-		Name:      "wavefront",
-	}}
+	return reconcile.Request{NamespacedName: util.ObjKey(wftest.DefaultNamespace, "wavefront")}
 }

--- a/internal/kubernetes/manager.go
+++ b/internal/kubernetes/manager.go
@@ -3,9 +3,10 @@ package kubernetes_manager
 import (
 	"context"
 
+	"github.com/wavefrontHQ/wavefront-operator-for-kubernetes/internal/util"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -42,10 +43,7 @@ func (km *KubernetesManager) ApplyResources(resourceYAMLs []string, exclude func
 
 		var oldObject unstructured.Unstructured
 		oldObject.SetGroupVersionKind(*gvk)
-		err = km.objClient.Get(context.TODO(), types.NamespacedName{
-			Namespace: object.GetNamespace(),
-			Name:      object.GetName(),
-		}, &oldObject)
+		err = km.objClient.Get(context.Background(), util.ObjKey(object.GetNamespace(), object.GetName()), &oldObject)
 		if errors.IsNotFound(err) {
 			err = km.objClient.Create(context.Background(), object)
 		} else if err == nil {

--- a/internal/kubernetes/manager.go
+++ b/internal/kubernetes/manager.go
@@ -47,6 +47,7 @@ func (km *KubernetesManager) ApplyResources(resourceYAMLs []string, exclude func
 		if errors.IsNotFound(err) {
 			err = km.objClient.Create(context.Background(), object)
 		} else if err == nil {
+			object.SetResourceVersion(oldObject.GetResourceVersion())
 			err = km.objClient.Patch(context.Background(), object, client.MergeFrom(&oldObject))
 		}
 		if err != nil {

--- a/internal/kubernetes/manager_test.go
+++ b/internal/kubernetes/manager_test.go
@@ -1,22 +1,22 @@
 package kubernetes_manager_test
 
 import (
+	"context"
+	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stretchr/testify/assert"
 	kubernetes_manager "github.com/wavefrontHQ/wavefront-operator-for-kubernetes/internal/kubernetes"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	fake2 "k8s.io/client-go/dynamic/fake"
-	"k8s.io/client-go/kubernetes/scheme"
-	testing2 "k8s.io/client-go/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func TestKubernetesManager(t *testing.T) {
-	t.Run("creates or updates kubernetes objects with resource yaml strings", func(t *testing.T) {
-		fakeServiceYaml := `
+const fakeServiceYAML = `
 apiVersion: v1
 kind: Service
 metadata:
@@ -33,50 +33,8 @@ spec:
     app.kubernetes.io/name: fake-app-kubernetes-name
   type: ClusterIP
 `
-		fakeYamls := []string{
-			fakeServiceYaml,
-			fakeServiceYaml, // duplicated to cause a patch
-		}
 
-		testRestMapper := meta.NewDefaultRESTMapper(
-			[]schema.GroupVersion{
-				{Group: "apps", Version: "v1"},
-			},
-		)
-		testRestMapper.Add(schema.GroupVersionKind{
-			Group:   "",
-			Version: "v1",
-			Kind:    "Service",
-		}, meta.RESTScopeNamespace)
-
-		clientBuilder := fake.NewClientBuilder()
-		clientBuilder = clientBuilder.WithRESTMapper(testRestMapper)
-
-		fakeApiClient := clientBuilder.Build()
-
-		s := scheme.Scheme
-		fakeDynamicClient := fake2.NewSimpleDynamicClient(s)
-
-		km, err := kubernetes_manager.NewKubernetesManager(
-			fakeApiClient.RESTMapper(),
-			fakeDynamicClient,
-		)
-		assert.NoError(t, err)
-
-		err = km.ApplyResources(fakeYamls, func(obj *unstructured.Unstructured) bool {
-			return false
-		})
-		assert.NoError(t, err)
-
-		// TODO: action count
-
-		assert.True(t, hasAction(fakeDynamicClient, "get", "services"), "get Service")
-		assert.True(t, hasAction(fakeDynamicClient, "create", "services"), "create Service")
-		assert.True(t, hasAction(fakeDynamicClient, "patch", "services"), "patch Service")
-	})
-
-	t.Run("deletes multiple kubernetes objects with resource yaml strings if they exist", func(t *testing.T) {
-		fakeServiceYaml := `
+const fakeServiceUpdatedYAML = `
 apiVersion: v1
 kind: Service
 metadata:
@@ -85,133 +43,173 @@ metadata:
   name: fake-name
   namespace: fake-namespace
 spec:
+  ports:
+  - name: fake-port-name
+    port: 1112
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: fake-app-kubernetes-name
   type: ClusterIP
 `
-		fakeMissingDeploymentYaml := `
-apiVersion: apps/v1
-kind: Deployment
+
+const otherFakeServiceYAML = `
+apiVersion: v1
+kind: Service
 metadata:
- labels:
-   app.kubernetes.io/component: fake-app-kubernetes-component
- name: fake-name
- namespace: fake-namespace
+  labels:
+    app.kubernetes.io/name: other-fake-app-kubernetes-name
+  name: other-fake-name
+  namespace: fake-namespace
 spec:
- replicas: 1
- selector:
-   matchLabels:
-     app.kubernetes.io/component: fake-app-kubernetes-component
-`
-		fakeDaemonsetYaml := `
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
- labels:
-   app.kubernetes.io/name: fake-app-kubernetes-name
-   app.kubernetes.io/component: fake-app-kubernetes-component
- name: fake-daemonset-name
- namespace: fake-namespace
-spec:
- selector:
-   matchLabels:
-     app.kubernetes.io/name: fake-app-kubernetes-name
-     app.kubernetes.io/component: fake-app-kubernetes-component
+  ports:
+  - name: fake-port-name
+    port: 1111
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: other-fake-app-kubernetes-name
+  type: ClusterIP
 `
 
-		fakeYamls := []string{
-			fakeServiceYaml,
-			fakeMissingDeploymentYaml,
-			fakeDaemonsetYaml,
-		}
+func TestKubernetesManager(t *testing.T) {
+	t.Run("applying", func(t *testing.T) {
+		t.Run("rejects invalid objects", func(t *testing.T) {
+			km := kubernetes_manager.NewKubernetesManager(fake.NewClientBuilder().Build())
 
-		testRestMapper := meta.NewDefaultRESTMapper(
-			[]schema.GroupVersion{
-				{Group: "apps", Version: "v1"},
-			},
-		)
-		testRestMapper.Add(schema.GroupVersionKind{
-			Group:   "",
-			Version: "v1",
-			Kind:    "Service",
-		}, meta.RESTScopeNamespace)
-		testRestMapper.Add(schema.GroupVersionKind{
-			Group:   "apps",
-			Version: "v1",
-			Kind:    "Deployment",
-		}, meta.RESTScopeNamespace)
-		testRestMapper.Add(schema.GroupVersionKind{
-			Group:   "apps",
-			Version: "v1",
-			Kind:    "DaemonSet",
-		}, meta.RESTScopeNamespace)
+			err := km.ApplyResources([]string{"invalid: {{object}}"}, excludeNothing)
 
-		clientBuilder := fake.NewClientBuilder()
-		clientBuilder = clientBuilder.WithRESTMapper(testRestMapper)
+			assert.ErrorContains(t, err, "yaml: invalid")
+		})
 
-		fakeApiClient := clientBuilder.Build()
+		t.Run("creates kubernetes objects", func(t *testing.T) {
+			objClient := fake.NewClientBuilder().Build()
+			km := kubernetes_manager.NewKubernetesManager(objClient)
 
-		s := scheme.Scheme
-		fakeDynamicClient := fake2.NewSimpleDynamicClient(s)
-		_ = fakeDynamicClient.Tracker().Add(&unstructured.Unstructured{Object: map[string]interface{}{
-			"apiVersion": "v1",
-			"kind":       "Service",
-			"metadata": map[string]interface{}{
-				"name":      "fake-name",
-				"namespace": "fake-namespace",
-				"labels": map[string]interface{}{
-					"app.kubernetes.io/name": "fake-app-kubernetes-name",
-				},
-			},
-			"spec": map[string]interface{}{
-				"type": "ClusterIP",
-			},
-		}})
-		_ = fakeDynamicClient.Tracker().Add(&unstructured.Unstructured{Object: map[string]interface{}{
-			"apiVersion": "apps/v1",
-			"kind":       "DaemonSet",
-			"metadata": map[string]interface{}{
-				"name":      "fake-daemonset-name",
-				"namespace": "fake-namespace",
-				"labels": map[string]interface{}{
-					"app.kubernetes.io/name":      "fake-app-kubernetes-name",
-					"app.kubernetes.io/component": "fake-app-kubernetes-component",
-				},
-			},
-		}})
+			assert.NoError(t, km.ApplyResources([]string{fakeServiceYAML}, excludeNothing))
 
-		km, err := kubernetes_manager.NewKubernetesManager(
-			fakeApiClient.RESTMapper(),
-			fakeDynamicClient,
-		)
-		assert.NoError(t, err)
+			require.NoError(t, objClient.Get(context.Background(), types.NamespacedName{
+				Namespace: "fake-namespace",
+				Name:      "fake-name",
+			}, &corev1.Service{}))
+		})
 
-		err = km.DeleteResources(fakeYamls)
-		assert.NoError(t, err)
-		// TODO: action count
+		t.Run("patches kubernetes objects", func(t *testing.T) {
+			objClient := fake.NewClientBuilder().Build()
+			km := kubernetes_manager.NewKubernetesManager(objClient)
 
-		assert.True(t, hasAction(fakeDynamicClient, "get", "services"), "get Service")
-		assert.True(t, hasAction(fakeDynamicClient, "delete", "services"), "delete Service")
-		assert.True(t, hasAction(fakeDynamicClient, "get", "deployments"), "get Deployment")
+			err := km.ApplyResources([]string{fakeServiceYAML, fakeServiceUpdatedYAML}, excludeNothing)
+			assert.NoError(t, err)
 
-		// Notice the 'False'; deployment didn't exist
-		assert.False(t, hasAction(fakeDynamicClient, "delete", "deployments"), "delete Deployment")
+			var service corev1.Service
+			require.NoError(t, objClient.Get(context.Background(), types.NamespacedName{
+				Namespace: "fake-namespace",
+				Name:      "fake-name",
+			}, &service))
 
-		assert.True(t, hasAction(fakeDynamicClient, "get", "daemonsets"), "get DaemonSet")
-		assert.True(t, hasAction(fakeDynamicClient, "delete", "daemonsets"), "delete DaemonSet")
+			require.Equal(t, int32(1112), service.Spec.Ports[0].Port)
+		})
+
+		t.Run("filters objects", func(t *testing.T) {
+			objClient := fake.NewClientBuilder().Build()
+			km := kubernetes_manager.NewKubernetesManager(objClient)
+
+			err := km.ApplyResources([]string{fakeServiceYAML}, excludeEverything)
+			assert.NoError(t, err)
+
+			require.Error(t, objClient.Get(context.Background(), types.NamespacedName{
+				Namespace: "fake-namespace",
+				Name:      "fake-name",
+			}, &corev1.Service{}))
+		})
+
+		t.Run("reports client errors", func(t *testing.T) {
+			km := kubernetes_manager.NewKubernetesManager(&errClient{errors.New("some error")})
+
+			err := km.ApplyResources([]string{fakeServiceYAML}, excludeNothing)
+			assert.Error(t, err)
+		})
+	})
+
+	t.Run("deleting", func(t *testing.T) {
+		t.Run("rejects invalid objects", func(t *testing.T) {
+			km := kubernetes_manager.NewKubernetesManager(fake.NewClientBuilder().Build())
+
+			err := km.DeleteResources([]string{"invalid: {{object}}"})
+
+			assert.ErrorContains(t, err, "yaml: invalid")
+		})
+
+		t.Run("deletes objects that exist", func(t *testing.T) {
+			objClient := fake.NewClientBuilder().Build()
+			km := kubernetes_manager.NewKubernetesManager(objClient)
+
+			_ = km.ApplyResources([]string{fakeServiceYAML}, excludeNothing)
+
+			require.NoError(t, km.DeleteResources([]string{fakeServiceYAML}))
+
+			assert.Error(t, objClient.Get(context.Background(), types.NamespacedName{
+				Namespace: "fake-namespace",
+				Name:      "fake-name",
+			}, &corev1.Service{}))
+
+		})
+
+		t.Run("reports client errors", func(t *testing.T) {
+			km := kubernetes_manager.NewKubernetesManager(&errClient{errors.New("some error")})
+
+			assert.Error(t, km.DeleteResources([]string{fakeServiceYAML}))
+		})
+
+		t.Run("does not return an error for objects that do not exist", func(t *testing.T) {
+			km := kubernetes_manager.NewKubernetesManager(fake.NewClientBuilder().Build())
+
+			require.NoError(t, km.DeleteResources([]string{fakeServiceYAML}))
+		})
+
+		t.Run("deletes all resources", func(t *testing.T) {
+			objClient := fake.NewClientBuilder().Build()
+			km := kubernetes_manager.NewKubernetesManager(objClient)
+
+			_ = km.ApplyResources([]string{fakeServiceYAML, otherFakeServiceYAML}, excludeNothing)
+
+			require.NoError(t, km.DeleteResources([]string{fakeServiceYAML, otherFakeServiceYAML}))
+
+			assert.Error(t, objClient.Get(context.Background(), types.NamespacedName{
+				Namespace: "fake-namespace",
+				Name:      "fake-name",
+			}, &corev1.Service{}))
+
+			assert.Error(t, objClient.Get(context.Background(), types.NamespacedName{
+				Namespace: "fake-namespace",
+				Name:      "other-fake-name",
+			}, &corev1.Service{}))
+		})
 	})
 }
 
-func hasAction(dynamicClient *fake2.FakeDynamicClient, verb, resource string) (result bool) {
-	if getAction(dynamicClient, verb, resource) != nil {
-		return true
-	}
+func excludeEverything(_ *unstructured.Unstructured) bool {
+	return true
+}
+
+func excludeNothing(_ *unstructured.Unstructured) bool {
 	return false
 }
 
-func getAction(dynamicClient *fake2.FakeDynamicClient, verb, resource string) (action testing2.Action) {
-	for _, action := range dynamicClient.Actions() {
-		if action.GetVerb() == verb && action.GetResource().Resource == resource {
-			return action
-		}
-	}
-	return nil
+type errClient struct {
+	err error
+}
+
+func (c *errClient) Get(_ context.Context, _ client.ObjectKey, _ client.Object) error {
+	return c.err
+}
+
+func (c *errClient) Create(_ context.Context, _ client.Object, _ ...client.CreateOption) error {
+	return c.err
+}
+
+func (c *errClient) Patch(_ context.Context, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+	return c.err
+}
+
+func (c *errClient) Delete(_ context.Context, _ client.Object, _ ...client.DeleteOption) error {
+	return c.err
 }

--- a/internal/util/k8s.go
+++ b/internal/util/k8s.go
@@ -1,0 +1,7 @@
+package util
+
+import "sigs.k8s.io/controller-runtime/pkg/client"
+
+func ObjKey(namespace string, name string) client.ObjectKey {
+	return client.ObjectKey{Namespace: namespace, Name: name}
+}

--- a/internal/validation/validate_wavefront.go
+++ b/internal/validation/validate_wavefront.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"fmt"
 
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/wavefrontHQ/wavefront-operator-for-kubernetes/internal/util"
 
 	wf "github.com/wavefrontHQ/wavefront-operator-for-kubernetes/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	typedappsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 )
 
 var legacyComponentsToCheck = map[string]map[string]string{
@@ -46,10 +48,10 @@ func (result Result) IsWarning() bool {
 	return result.error != nil && !result.isError
 }
 
-func Validate(appsV1 typedappsv1.AppsV1Interface, wavefront *wf.Wavefront) Result {
-	err := validateEnvironment(appsV1, wavefront)
+func Validate(objClient client.Client, wavefront *wf.Wavefront) Result {
+	err := validateEnvironment(objClient, wavefront)
 	if err != nil {
-		return Result{err, !areAnyComponentsDeployed(appsV1, wavefront.Spec.Namespace)}
+		return Result{err, !areAnyComponentsDeployed(objClient, wavefront.Spec.Namespace)}
 	}
 	err = validateWavefrontSpec(wavefront)
 	if err != nil {
@@ -58,19 +60,19 @@ func Validate(appsV1 typedappsv1.AppsV1Interface, wavefront *wf.Wavefront) Resul
 	return Result{}
 }
 
-func validateEnvironment(appsV1 typedappsv1.AppsV1Interface, wavefront *wf.Wavefront) error {
+func validateEnvironment(objClient client.Client, wavefront *wf.Wavefront) error {
 	if wavefront.Spec.AllowLegacyInstall {
 		return nil
 	}
 	for namespace, resourceMap := range legacyComponentsToCheck {
 		for resourceName, resourceType := range resourceMap {
 			if resourceType == util.DaemonSet {
-				if daemonSetExists(appsV1.DaemonSets(namespace), resourceName) {
+				if daemonSetExists(objClient, namespace, resourceName) {
 					return legacyEnvironmentError(namespace)
 				}
 			}
 			if resourceType == util.Deployment {
-				if deploymentExists(appsV1.Deployments(namespace), resourceName) {
+				if deploymentExists(objClient, namespace, resourceName) {
 					return legacyEnvironmentError(namespace)
 				}
 			}
@@ -117,26 +119,34 @@ func compareQuantities(request string, limit string) int {
 	return requestQuantity.Cmp(limitQuanity)
 }
 
-func deploymentExists(deployments typedappsv1.DeploymentInterface, resourceName string) bool {
-	_, err := deployments.Get(context.Background(), resourceName, v1.GetOptions{})
+func deploymentExists(client client.Client, namespace string, name string) bool {
+	var ds appsv1.Deployment
+	err := client.Get(context.Background(), types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}, &ds)
 	return err == nil
 }
 
-func daemonSetExists(daemonsets typedappsv1.DaemonSetInterface, resourceName string) bool {
-	_, err := daemonsets.Get(context.Background(), resourceName, v1.GetOptions{})
+func daemonSetExists(client client.Client, namespace string, name string) bool {
+	var ds appsv1.DaemonSet
+	err := client.Get(context.Background(), types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}, &ds)
 	return err == nil
 }
 
-func areAnyComponentsDeployed(appsV1 typedappsv1.AppsV1Interface, namespace string) bool {
-	exists := deploymentExists(appsV1.Deployments(namespace), util.ProxyName)
+func areAnyComponentsDeployed(client client.Client, namespace string) bool {
+	exists := deploymentExists(client, namespace, util.ProxyName)
 	if exists {
 		return exists
 	}
-	exists = daemonSetExists(appsV1.DaemonSets(namespace), util.NodeCollectorName)
+	exists = daemonSetExists(client, namespace, util.NodeCollectorName)
 	if exists {
 		return exists
 	}
-	exists = deploymentExists(appsV1.Deployments(namespace), util.ClusterCollectorName)
+	exists = deploymentExists(client, namespace, util.ClusterCollectorName)
 	if exists {
 		return exists
 	}

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -68,7 +69,8 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	config := ctrl.GetConfigOrDie()
+	mgr, err := ctrl.NewManager(config, ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     "0",
 		Port:                   9443,
@@ -80,7 +82,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	controller, err := controllers.NewWavefrontReconciler(version, mgr.GetClient())
+	objClient, err := client.New(config, client.Options{Scheme: scheme})
+	if err != nil {
+		setupLog.Error(err, "error creating reconciler client")
+		os.Exit(1)
+	}
+
+	controller, err := controllers.NewWavefrontReconciler(version, objClient)
 	if err != nil {
 		setupLog.Error(err, "error creating wavefront operator reconciler")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -80,8 +80,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	var controller *controllers.WavefrontReconciler
-	controller, err = controllers.NewWavefrontReconciler(version, mgr.GetClient(), mgr.GetScheme())
+	controller, err := controllers.NewWavefrontReconciler(version, mgr.GetClient())
 	if err != nil {
 		setupLog.Error(err, "error creating wavefront operator reconciler")
 		os.Exit(1)


### PR DESCRIPTION
Right now, we're using
 * `client.Client`: reading the CR & updating health status (provided by the controller runtime)
 * `kubernetes.Interface`: reads against the k8s API
 * `dynamic.Interface`: applying/deleting our resources from the FS

`client.Client` can do everything that we need. When working on previous test improvements, I discovered that `client.Client` is provided by the controller runtime because operators often need to work with a diverse set of k8s objects (some typed, some untyped).  So`client.Client` is flexible enough to do type-safe calls like `kubernetes.Interface` while also being able to apply unknown/arbitrary types which we were using `dynamic.Interface` for.